### PR TITLE
Project and Dataset sorting UI

### DIFF
--- a/web/shapeworks/src/components/NavBar.vue
+++ b/web/shapeworks/src/components/NavBar.vue
@@ -1,7 +1,7 @@
 <script lang="ts">
 import { computed } from 'vue'
 import { logout, oauthClient } from '@/api/auth';
-import { allDatasets, loadingState, selectedDataset, selectedProject } from '@/store';
+import { allDatasets, loadingState, projectSortOption, projectSortAscending, selectedDataset, selectedProject, projectFilters, SORT_OPTION } from '@/store';
 import FilterSearch from './FilterSearch.vue';
 import router from '@/router';
 import { getDatasets } from '@/api/rest';
@@ -16,6 +16,10 @@ export default {
         dataset: selectedDataset.value?.id,
         project: selectedProject.value?.id
       }))
+
+      const ascendingLabel = computed(() => {
+        return projectSortOption.value !== 'modified' ? "A to Z" : "Oldest"
+      })
 
       async function logInOrOut() {
           if (oauthClient.isLoggedIn) {
@@ -48,6 +52,11 @@ export default {
           selectedDataset,
           selectedProject,
           navigateToHome,
+          projectSortOption,
+          projectSortAscending,
+          ascendingLabel,
+          projectFilters,
+          SORT_OPTION,
           router,
       }
     }
@@ -67,6 +76,59 @@ export default {
     </div>
     <v-spacer />
     <filter-search v-if="!(selectedDataset && selectedProject) && !(router.currentRoute.params.dataset && router.currentRoute.params.project)"/>
+    <v-menu offset-y :close-on-content-click="false">
+      <template v-slot:activator="{ on, attrs }">
+        <v-btn
+          class="ma-5"
+          v-if="!(selectedDataset && selectedProject) && !(router.currentRoute.params.dataset && router.currentRoute.params.project)"
+          hover
+          icon
+          v-bind="attrs"
+          v-on="on"
+        >
+          <v-icon>
+            mdi-filter-variant
+          </v-icon>
+        </v-btn>
+      </template>
+      <v-card>
+        <v-expansion-panels>
+          <v-expansion-panel>
+            <v-expansion-panel-header>Sort</v-expansion-panel-header>
+            <v-expansion-panel-content>
+              <v-card-text>
+                <div class="flex">
+                  <v-select
+                    v-model="projectSortOption"
+                    :items="Object.values(SORT_OPTION)"
+                    label="Sort by"
+                  />
+                  <v-switch
+                    v-model="projectSortAscending"
+                    :label="ascendingLabel"
+                  />
+                </div>
+              </v-card-text>
+            </v-expansion-panel-content>
+          </v-expansion-panel>
+          <v-expansion-panel>
+            <v-expansion-panel-header>Filter</v-expansion-panel-header>
+            <v-expansion-panel-content>
+              <v-card-text>
+                <v-switch
+                  v-model="projectFilters.private"
+                  label="Hide private projects"
+                />
+                <v-switch
+                  v-model="projectFilters.readonly"
+                  label="Hide read only projects"
+                />
+              </v-card-text>
+            </v-expansion-panel-content>
+          </v-expansion-panel>
+        </v-expansion-panels>
+      </v-card>
+    </v-menu>
     <v-spacer />
     <v-btn
       v-if="oauthClient.isLoggedIn"

--- a/web/shapeworks/src/components/NavBar.vue
+++ b/web/shapeworks/src/components/NavBar.vue
@@ -1,7 +1,7 @@
 <script lang="ts">
 import { computed } from 'vue'
 import { logout, oauthClient } from '@/api/auth';
-import { allDatasets, loadingState, projectSortOption, projectSortAscending, selectedDataset, selectedProject, projectFilters, SORT_OPTION } from '@/store';
+import { allDatasets, loadingState, sortOption, sortAscending, selectedDataset, selectedProject, filters, SORT_OPTION } from '@/store';
 import FilterSearch from './FilterSearch.vue';
 import router from '@/router';
 import { getDatasets } from '@/api/rest';
@@ -18,7 +18,7 @@ export default {
       }))
 
       const ascendingLabel = computed(() => {
-        return projectSortOption.value !== 'modified' ? "A to Z" : "Oldest"
+        return sortOption.value !== 'modified' ? "A to Z" : "Oldest"
       })
 
       async function logInOrOut() {
@@ -52,10 +52,10 @@ export default {
           selectedDataset,
           selectedProject,
           navigateToHome,
-          projectSortOption,
-          projectSortAscending,
+          sortOption,
+          sortAscending,
           ascendingLabel,
-          projectFilters,
+          filters,
           SORT_OPTION,
           router,
       }
@@ -99,29 +99,29 @@ export default {
               <v-card-text>
                 <div class="flex">
                   <v-select
-                    v-model="projectSortOption"
+                    v-model="sortOption"
                     :items="Object.values(SORT_OPTION)"
                     label="Sort by"
                   />
                   <v-switch
-                    v-model="projectSortAscending"
+                    v-model="sortAscending"
                     :label="ascendingLabel"
                   />
                 </div>
               </v-card-text>
             </v-expansion-panel-content>
           </v-expansion-panel>
-          <v-expansion-panel>
+          <v-expansion-panel v-if="selectedDataset">
             <v-expansion-panel-header>Filter</v-expansion-panel-header>
             <v-expansion-panel-content>
               <v-card-text>
                 <v-switch
-                  v-model="projectFilters.private"
-                  label="Hide private projects"
+                  v-model="filters.private"
+                  label="Hide private"
                 />
                 <v-switch
-                  v-model="projectFilters.readonly"
-                  label="Hide read only projects"
+                  v-model="filters.readonly"
+                  label="Hide read only"
                 />
               </v-card-text>
             </v-expansion-panel-content>

--- a/web/shapeworks/src/components/ProjectForm.vue
+++ b/web/shapeworks/src/components/ProjectForm.vue
@@ -114,6 +114,7 @@ export default {
         v-else
         class="selectable-card"
         @click.stop
+        :ripple="false"
     >
         <div v-if="!editMode" class="text-overline mb-4">
             NEW PROJECT FOR DATASET {{selectedDataset.id}}

--- a/web/shapeworks/src/store/constants.ts
+++ b/web/shapeworks/src/store/constants.ts
@@ -84,3 +84,10 @@ export const COLORS = [
 ];
 
 export const DEEPSSM_SAMPLES_PER_PAGE = 12;
+
+export enum SORT_OPTION {
+    NAME = 'name',
+    ID = 'id',
+    MODIFIED = 'modified',
+    CREATOR = 'creator',
+}

--- a/web/shapeworks/src/store/index.ts
+++ b/web/shapeworks/src/store/index.ts
@@ -3,9 +3,11 @@ import {
     DataObject, Dataset, Subject,
     Particles, GroomedShape, Project,
     ReconstructedSample, VTKInstance,
-    Analysis, Task, LandmarkInfo, Constraints
+    Analysis, Task, LandmarkInfo, Constraints,
+    ProjectFilters
 } from '@/types'
 import { ref } from 'vue'
+import { SORT_OPTION } from './constants';
 
 export * from './methods'
 
@@ -144,3 +146,12 @@ export const uniformScale = ref<boolean>(true);
 export const deepSSMErrorGlobalRange = ref<number[]>([0, 1]);
 
 export const deepSSMSamplePage = ref<number>(1);
+
+export const projectSortAscending = ref(true);
+
+export const projectSortOption = ref<SORT_OPTION>(SORT_OPTION.NAME);
+
+export const projectFilters = ref<ProjectFilters>({
+    private: false,
+    readonly: false,
+});

--- a/web/shapeworks/src/store/index.ts
+++ b/web/shapeworks/src/store/index.ts
@@ -4,7 +4,7 @@ import {
     Particles, GroomedShape, Project,
     ReconstructedSample, VTKInstance,
     Analysis, Task, LandmarkInfo, Constraints,
-    ProjectFilters
+    Filters
 } from '@/types'
 import { ref } from 'vue'
 import { SORT_OPTION } from './constants';
@@ -147,11 +147,11 @@ export const deepSSMErrorGlobalRange = ref<number[]>([0, 1]);
 
 export const deepSSMSamplePage = ref<number>(1);
 
-export const projectSortAscending = ref(true);
+export const sortAscending = ref(true);
 
-export const projectSortOption = ref<SORT_OPTION>(SORT_OPTION.NAME);
+export const sortOption = ref<SORT_OPTION>(SORT_OPTION.NAME);
 
-export const projectFilters = ref<ProjectFilters>({
+export const filters = ref<Filters>({
     private: false,
     readonly: false,
 });

--- a/web/shapeworks/src/types/index.ts
+++ b/web/shapeworks/src/types/index.ts
@@ -81,6 +81,7 @@ export interface Analysis {
 
 export interface Project {
     id: number,
+    creator: number,
     name: string,
     file: string,
     file_contents: Object | undefined,
@@ -100,6 +101,7 @@ export interface Project {
 
 export interface Dataset {
     id: number,
+    creator: number,
     name: string,
     file: string,
     private: boolean,
@@ -248,4 +250,9 @@ export interface DeepSSMImage {
     index: string,
     image: string,
     validation: boolean,
+}
+
+export interface ProjectFilters {
+    private: boolean,
+    readonly: boolean,
 }

--- a/web/shapeworks/src/types/index.ts
+++ b/web/shapeworks/src/types/index.ts
@@ -252,7 +252,7 @@ export interface DeepSSMImage {
     validation: boolean,
 }
 
-export interface ProjectFilters {
+export interface Filters {
     private: boolean,
     readonly: boolean,
 }

--- a/web/shapeworks/src/views/DatasetSelect.vue
+++ b/web/shapeworks/src/views/DatasetSelect.vue
@@ -1,5 +1,5 @@
 <script lang="ts">
-import { onMounted, ref, watch } from 'vue';
+import { computed, onMounted, ref, watch } from 'vue';
 import {
     allDatasets,
     selectedDataset,
@@ -7,6 +7,8 @@ import {
     selectedDataObjects,
     loadProjectsForDataset,
     getAllDatasets,
+sortOption,
+sortAscending,
 } from '@/store';
 import { Dataset } from '@/types';
 import SubsetSelection from '@/components/SubsetSelection.vue';
@@ -23,6 +25,30 @@ export default {
     setup(props) {
         const selectingSubsetOf = ref();
         selectedDataset.value = undefined;
+
+        const sortedDatasets = computed(() => {
+            if (allDatasets.value) {
+                const datasets = allDatasets.value.sort((a, b) => {
+                    let sortA = a[sortOption.value];
+                    let sortB = b[sortOption.value];
+
+                    if ((!sortA || !sortB)) {
+                        return 0;
+                    }
+
+                    if (sortA < sortB) {
+                        return (sortAscending.value === true) ? -1 : 1;
+                    }
+                    if (sortA > sortB) {
+                        return (sortAscending.value === true) ? 1 : -1;
+                    }
+                    return 0;
+                });
+
+                return datasets;
+            }
+            return [];
+        });
 
         async function selectOrDeselectDataset (dataset: Dataset | undefined) {
             if(!selectedDataset.value && dataset) {
@@ -59,6 +85,7 @@ export default {
             selectOrDeselectDataset,
             selectingSubsetOf,
             loadingState,
+            sortedDatasets,
         }
     }
 }
@@ -75,7 +102,7 @@ export default {
                 <v-card-title>No datasets.</v-card-title>
             </v-card>
             <v-card
-                v-for="dataset in allDatasets"
+                v-for="dataset in sortedDatasets"
                 :key="'dataset_'+dataset.id"
                 :class="dataset.thumbnail? 'selectable-card with-thumbnail': 'selectable-card'"
                 v-show="!selectedDataset || selectedDataset == dataset"

--- a/web/shapeworks/src/views/ProjectSelect.vue
+++ b/web/shapeworks/src/views/ProjectSelect.vue
@@ -12,9 +12,9 @@ import {
     getAllDatasets,
     loadDataset,
     loadProjectsForDataset,
-    projectSortAscending,
-    projectSortOption,
-    projectFilters,
+    sortAscending,
+    sortOption,
+    filters,
 } from '@/store';
 import ProjectForm from '@/components/ProjectForm.vue';
 import { Project } from '@/types';
@@ -38,27 +38,27 @@ export default {
         const sortedProjects = computed(() => {
             if (allProjectsForDataset.value) {
                 let projects = allProjectsForDataset.value.sort((a, b) => {
-                    let sortA = a[projectSortOption.value];
-                    let sortB = b[projectSortOption.value];
+                    let sortA = a[sortOption.value];
+                    let sortB = b[sortOption.value];
 
                     if ((!sortA || !sortB)) {
                         return 0;
                     }
 
                     if (sortA < sortB) {
-                        return (projectSortAscending.value === true) ? -1 : 1;
+                        return (sortAscending.value === true) ? -1 : 1;
                     }
                     if (sortA > sortB) {
-                        return (projectSortAscending.value === true) ? 1 : -1;
+                        return (sortAscending.value === true) ? 1 : -1;
                     }
                     return 0;
                 });
 
                 projects = projects.filter((p) => {
-                    if (projectFilters.value.private) {
+                    if (filters.value.private) {
                         return !p.private;
                     }
-                    if (projectFilters.value.readonly) {
+                    if (filters.value.readonly) {
                         return !p.readonly;
                     }
                     return true;

--- a/web/shapeworks/src/views/ProjectSelect.vue
+++ b/web/shapeworks/src/views/ProjectSelect.vue
@@ -1,5 +1,5 @@
 <script lang="ts">
-import { onMounted, ref, watch } from 'vue';
+import { computed, onMounted, ref, watch } from 'vue';
 import { cloneProject, deleteProject } from '@/api/rest'
 import {
     selectedDataset,
@@ -12,6 +12,9 @@ import {
     getAllDatasets,
     loadDataset,
     loadProjectsForDataset,
+    projectSortAscending,
+    projectSortOption,
+    projectFilters,
 } from '@/store';
 import ProjectForm from '@/components/ProjectForm.vue';
 import { Project } from '@/types';
@@ -31,6 +34,40 @@ export default {
     },
     setup(props) {
         const deleting = ref();
+
+        const sortedProjects = computed(() => {
+            if (allProjectsForDataset.value) {
+                let projects = allProjectsForDataset.value.sort((a, b) => {
+                    let sortA = a[projectSortOption.value];
+                    let sortB = b[projectSortOption.value];
+
+                    if ((!sortA || !sortB)) {
+                        return 0;
+                    }
+
+                    if (sortA < sortB) {
+                        return (projectSortAscending.value === true) ? -1 : 1;
+                    }
+                    if (sortA > sortB) {
+                        return (projectSortAscending.value === true) ? 1 : -1;
+                    }
+                    return 0;
+                });
+
+                projects = projects.filter((p) => {
+                    if (projectFilters.value.private) {
+                        return !p.private;
+                    }
+                    if (projectFilters.value.readonly) {
+                        return !p.readonly;
+                    }
+                    return true;
+                })
+
+                return projects;
+            }
+            return [];
+        });
 
         async function selectOrDeselectProject (project: Project) {
             if(!selectedProject.value){
@@ -98,6 +135,7 @@ export default {
             selectProject,
             back,
             loadingState,
+            sortedProjects,
         }
     }
 }
@@ -116,7 +154,7 @@ export default {
                 <v-card-title>No projects.</v-card-title>
             </v-card>
             <div
-                v-for="project in allProjectsForDataset"
+                v-for="project in sortedProjects"
                 :key="'project_'+project.id"
                 @click="() => selectOrDeselectProject(project)"
             >
@@ -189,6 +227,8 @@ export default {
                     </v-card-actions>
                 </v-card>
             </div>
+            <!-- Create project form (shows at end of list). Does this need more advanced perms? -->
+            <project-form />
             <v-dialog
                 :value="deleting"
                 width="500"

--- a/web/shapeworks/src/views/ProjectSelect.vue
+++ b/web/shapeworks/src/views/ProjectSelect.vue
@@ -55,12 +55,16 @@ export default {
                 });
 
                 projects = projects.filter((p) => {
+                    if (filters.value.private && filters.value.readonly) {
+                        return !p.private && !p.readonly;
+                    }
                     if (filters.value.private) {
                         return !p.private;
                     }
                     if (filters.value.readonly) {
                         return !p.readonly;
                     }
+
                     return true;
                 })
 


### PR DESCRIPTION
Closes #381 

Adds sorting to Datasets and Project page. Also adds filter options for projects.

There aren't many possible filtering options for Datasets (that are exposed at least). If there are some useful ones, it shouldn't be too taxing to add additional filters or dataset/project specific filters.

Dataset and Project sorting/filtering example: 
*note* all the creators are my own account, so that sort does nothing in my local
![sw-cloud-sorting-filtering](https://github.com/user-attachments/assets/df62af21-573e-482a-8182-12b2cb48d09d)
